### PR TITLE
Add updated OAS definition for delegationscheme lookup and registration

### DIFF
--- a/pages/eoppslag/assets/delegations_0.2.0_oas.yaml
+++ b/pages/eoppslag/assets/delegations_0.2.0_oas.yaml
@@ -1,0 +1,503 @@
+---
+openapi: 3.0.2
+info:
+  title: Maskinporten Delegeringskilde API
+  description: API som delegeringskilder må implementere for integrasjon med Maskinportens
+    tilgangskontroll
+  contact:
+    name: Bjørn Dybvik Langfors
+    email: bdl@brreg.no
+  version: 0.2.0
+paths:
+  /delegations/:
+    summary: Henter ut en liste over alle delegeringer som er gjort på et scope
+    description: 'Scope oppgis som query-parameter for å unngå problemer med "/" i
+      paths. Kan filtreres på `consumer_org`, som returnerer alle delegeringer gitt
+      av oppgitt organisasjonsnummer. Hvis `supplier_org` oppgis, returneres alle
+      delegeringer som oppgitt organisasjonsnummer har mottatt. En, begge eller ingen
+      av parameterene kan oppgis. '
+    get:
+      summary: Liste over alle delegeringer som er gjort på et scope
+      operationId: getDelegations
+      responses:
+        200:
+          description: Liste over alle delegeringer som er gjort på dette scopet.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Delegation'
+    parameters:
+    - name: scope
+      in: query
+      description: Scope som registrert i ID-porten
+      required: true
+      schema:
+        type: string
+    - name: consumer_org
+      in: query
+      description: Viser delegeringer begrenset til de utført av oppgitt organisasjonsnummer
+      schema:
+        type: string
+    - name: supplier_org
+      in: query
+      description: Viser delegeringer begrenset til de gitt til oppgitt organisasjonsnummer
+      schema:
+        type: string
+  /delegationSchemes:
+    summary: Hente ut liste over registrerte delegeringsoppsett eller registrere et
+      nytt
+    description: Endepunkt for å hente ut en liste over delegeringsoppsett (valgfritt
+      filtrert på eier), eller for å poste et nytt oppsett.
+    get:
+      summary: Lister ut alle delegeringsoppsett
+      description: Returnerer en liste over alle delegeringsoppsett, valgfritt filtrert
+        på oppgitt owner_id
+      operationId: getDelegationSchemes
+      parameters:
+      - name: owner_id
+        in: query
+        description: Begrens liste til delegeringsoppsett eid av oppgitt owner_id
+        schema:
+          type: string
+      responses:
+        200:
+          description: Returnerer en liste av delegeringsoppsett
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DelegationScheme'
+    post:
+      summary: Opprett et delegeringsoppsett
+      description: Lager et nytt delegeringsoppsett.
+      operationId: createDelegationScheme
+      requestBody:
+        description: Delegeringsoppsett som ønskes opprettet.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DelegationScheme'
+        required: true
+      responses:
+        201:
+          description: Delegeringsoppsettet er opprettet.
+        400:
+          description: Ugyldig delegeringsoppsett. Se respons for nærmere forklaring.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: Ingen tilgang til å opprette oppgitt delegeringsoppsett. Se
+            respons for nærmere forklaring.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        409:
+          description: Et delegeringsskjema med samme id finnes allerede.
+  /delegationSchemes/{delegationSchemeId}:
+    summary: Path for å administrere et enkelt delegeringsoppsett
+    description: 'Endepunkt for å hente, oppdatere og slette spesifikke delegeringsoppsett.
+      Avhengig av delegeringskilde og om det foreligger delegeringer knyttet til oppgitte
+      oppsettet vil skriveoperasjoner kunne nektes av delegeringskilden. '
+    get:
+      summary: Hent et delegeringsoppsett
+      description: Hent informasjon om et enkelt delegeringsoppsett.
+      operationId: getDelegationScheme
+      responses:
+        200:
+          description: Returnerer et delegeringsoppsett som definert av `DelegationScheme`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegationScheme'
+        404:
+          description: Forespurte delegeringsoppsett ble ikke funnet.
+    put:
+      summary: Oppdaterer et delegeringsoppsett
+      description: Oppdaterer et delegeringsoppsett.
+      operationId: updateDelegationScheme
+      requestBody:
+        description: Oppdatert delegeringsoppsett
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DelegationScheme'
+        required: true
+      responses:
+        202:
+          description: Delegeringsoppsettet ble oppdatert.
+        400:
+          description: Ugyldig delegeringsoppsett. Se respons for nærmere forklaring.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: Ikke tilgang til å oppdatere delegeringsoppsettet. Nærmere
+            forklaring ligger i response body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Forespurte delegeringsoppsett ble ikke funnet.
+    delete:
+      summary: Slett et delegeringsoppsett
+      description: Sletter et eksisterende delegeringsoppsett, hvis delegeringsskilden
+        tillater det.
+      operationId: deleteDelegationScheme
+      responses:
+        204:
+          description: Oppsettet ble slettet.
+        403:
+          description: Kunne ikke slette delegeringsoppsettet. Nærmere forklaring
+            ligger i response body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Forespurte delegeringsoppsett ble ikke funnet.
+    parameters:
+    - name: delegationSchemeId
+      in: path
+      description: ID på delegeringsoppsett
+      required: true
+      schema:
+        type: string
+  /delegationSchemeOwners/{delegationSchemeOwnerId}:
+    summary: Path for å administrere en enkelt eier av delegeringsoppsett
+    description: 'Endepunkt for å hente, oppdatere og slette spesifikke eiere delegeringsoppsett.
+      Avhengig av delegeringskilde og om det foreligger delegeringsoppsettet knyttet
+      til oppgitte oppsettet vil skriveoperasjoner kunne nektes av delegeringskilden. '
+    get:
+      summary: Hent en eier av delegeringsoppsett
+      description: Henter ut detaljer om en enkelt eier av delegeringsoppsett
+      operationId: getDelegationSchemeOwner
+      responses:
+        200:
+          description: Returnerer en eier av et delegeringsoppsett
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DelegationSchemeOwner'
+        404:
+          description: Oppgitt eier ble ikke funnet
+    put:
+      summary: Oppdater en eier av delegeringsoppsett
+      description: Oppdaterer en eksisterende eier av delegeringsoppsett
+      operationId: updateDelegationSchemeOwner
+      requestBody:
+        description: Oppdatert eier av delegeringsoppsett
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DelegationSchemeOwner'
+        required: true
+      responses:
+        202:
+          description: Eier av delegeringsoppsettet ble oppdatert.
+        400:
+          description: Ugyldig eier av delegeringsoppsett. Se respons for nærmere
+            forklaring.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: Ikke tilgang til å oppdatere eier av delegeringsoppsettet.
+            Nærmere forklaring ligger i response body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Forespurte eier av delegeringsoppsett ble ikke funnet.
+    delete:
+      summary: Sletter en eier av delegeringsoppsett
+      description: Sletter en eier av et eksisterende delegeringsoppsett.
+      operationId: deleteDelegationSchemeOwner
+      responses:
+        204:
+          description: Eier av delegeringsoppsettet ble slettet.
+        403:
+          description: Kunne ikke slette eier av delegeringsoppsettet. Nærmere forklaring
+            ligger i response body.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        404:
+          description: Forespurte eier delegeringsoppsett ble ikke funnet.
+    parameters:
+    - name: delegationSchemeOwnerId
+      in: path
+      description: ID på eier av delegeringsoppsett
+      required: true
+      schema:
+        type: string
+  /delegationSchemeOwners:
+    summary: Hente ut liste over registrerte eiere av delegeringsoppsett eller registrere
+      en ny
+    description: Endepunkt for å hente ut en liste over eiere av delegeringsoppsett,
+      eller for å poste en ny eier.
+    get:
+      summary: Liste ut eiere
+      description: Henter ut en liste over alle registrerte eiere
+      operationId: getDelegationSchemeOwners
+      responses:
+        200:
+          description: Returnerer en liste over alle registrerte eiere av delegeringsoppsett.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/DelegationSchemeOwner'
+    post:
+      summary: Opprett en eier av delegeringsoppsett
+      description: Lager en ny eier av delegeringsoppsett
+      operationId: createDelegationSchemeOwner
+      requestBody:
+        description: Eieren som skal opprettes.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DelegationSchemeOwner'
+        required: true
+      responses:
+        201:
+          description: Eier opprettet.
+        400:
+          description: Ugyldig oppgitt eier av delegeringsoppsett. Se respons for
+            nærmere forklaring.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        403:
+          description: Ingen tilgang til å opprette oppgitt eier av delegeringsoppsett.
+            Se respons for nærmere forklaring.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        409:
+          description: Eieren av delegeringsoppsett finnes allerede.
+components:
+  schemas:
+    Delegation:
+      title: Root Type for Delegation
+      description: The root of the Delegation type's schema.
+      type: object
+      properties:
+        consumer_org:
+          description: Organisasjonsnummer til aktøren som gir delegeringen
+          type: string
+        supplier_org:
+          description: Organisasjonsnummer til aktøren som har fått delegert tilgang
+          type: string
+        delegation_scheme:
+          description: Navn på delegeringsoppsett som det ble delegert på. Inkluderer
+            scope-prefix.
+          type: string
+        includes_scopes:
+          description: Hvilke scopes som er definert under dette delegeringsoppsettet.
+            Inkluderer scope-prefix.
+          type: array
+          items:
+            type: string
+        created:
+          format: date-time
+          description: UTC-tidspunkt for når delegeringen fant sted
+          type: string
+      example: |-
+        {
+            "consumer_org": "987654321",
+            "supplier_org": "976543210",
+            "delegation_scheme": "difi:krr_read",
+            "includes_scopes": [
+                "difi:user/kontaktinfo.read",
+                "difi:user/varsling.read"
+            ],
+            "created": "2018-01-01T12:00:00Z"
+        }
+    DelegationSourceConfigurationItem:
+      title: Root Type for DelegationSourceConfigurationItem
+      description: Generisk nøkkel/verdi-par for å kunne oppgi vilkårlige attributter
+        for en delegationScheme spesifikke for valgt delegationSource
+      required:
+      - key
+      - value
+      type: object
+      properties:
+        key:
+          description: Nøkkelnavn for konfigurasjonsfelt
+          pattern: ^[a-zA-Z0-9_]+$
+          type: string
+        value:
+          description: Nøkkelverdi for konfigurasjonsfelt
+          type: string
+      example: "{ \n    \"key\": \"roles\",\n    \"value\": \"PRIV,UTINN\"\n}"
+    LocalizedString:
+      description: Modell for å utrykke en streng i flere språk / locales.
+      required:
+      - default
+      type: object
+      properties:
+        default:
+          description: Representasjon som skal brukes når ingen andre språk er oppgitt
+            eller er aktuelle
+          type: string
+        lang:
+          description: Liste med oversettelser av strengen i ulike språk/locales
+          type: array
+          items:
+            $ref: '#/components/schemas/LocalizedStringItem'
+      example:
+        value: Departementenes sikkerhets- og serviceorganisasjon
+        lang:
+        - code: nb_NO
+          value: Departementenes sikkerhets- og serviceorganisasjon
+        - code: nn_NO
+          value: Tryggings- og serviceorganisasjonen til departementa
+        - code: en_GB
+          value: Norwegian Government Security and Service Organisation
+        - code: en_US
+          value: Norwegian Government Security and Service Organization
+    LocalizedStringItem:
+      title: Root Type for LocalizedStringItem
+      description: En streng oppgitt i henhold til et språk/locale som definert i
+        IETF BCP 47
+      required:
+      - code
+      - value
+      type: object
+      properties:
+        code:
+          description: IETF BCP 47 language tag
+          type: string
+        value:
+          description: Verdi for strengen i oppgitt språk/locale
+          type: string
+      example: '{ "code": "nb_NO", "value": "Departementenes sikkerhets- og serviceorganisasjon"
+        }'
+    DelegationSchemeOwner:
+      title: Root Type for DelegationSchemeOwner
+      description: Beskriver en eier av et delegeringsoppsett
+      required:
+      - id
+      - name
+      type: object
+      properties:
+        id:
+          description: Unik identifikator for eier av delegeringsoppsett. I Norge
+            er dette organisasjonsnummer fra enhetsregisteret.
+          pattern: ^[a-zA-Z0-9_]+$
+          type: string
+        name:
+          $ref: '#/components/schemas/LocalizedString'
+          description: Navn på eier av delegeringsoppsett
+      example:
+        id: "974761424"
+        name:
+          value: Departementenes sikkerhets- og serviceorganisasjon
+          lang:
+          - code: nb_NO
+            value: Departementenes sikkerhets- og serviceorganisasjon
+          - code: nn_NO
+            value: Tryggings- og serviceorganisasjonen til departementa
+          - code: en_GB
+            value: Norwegian Government Security and Service Organisation
+          - code: en_US
+            value: Norwegian Government Security and Service Organization
+    DelegationScheme:
+      title: Root Type for DelegationSchemeDefinition
+      description: Modell som beskriver et delegeringsoppsett. Dette vil tilgjengeliggjøres
+        som en delegerbar ressurs i oppgitt delegeringskilde.
+      required:
+      - id
+      - delegation_scheme_owner_id
+      type: object
+      properties:
+        title:
+          $ref: '#/components/schemas/LocalizedString'
+          description: Menneske-vennlig tittel for delegeringsoppsett
+        description:
+          $ref: '#/components/schemas/LocalizedString'
+          description: Valgfri beskrivelse av delegeringsoppsett
+          maxLength: 300
+        delegation_source:
+          description: Identifikator for kilden hvor delegeringer på knyttet til dette
+            delegeringsoppsettet utføres.
+          pattern: ^[a-zA-Z0-9_]+$
+          type: string
+          example: altinn
+        delegation_source_config:
+          description: Valgfri liste med nøkkel-verdi-par som benyttes mot delegeringskilden.
+          type: array
+          items:
+            $ref: '#/components/schemas/DelegationSourceConfigurationItem'
+        delegation_scheme_owner_id:
+          description: Eier av delegeringsoppsettet. Må referere en eksisterende `delegationSchemeOwner`
+            entitet
+          type: string
+        id:
+          description: Identifikator for delegeringsoppsett
+          pattern: ^[a-zA-Z0-9_]+$
+          type: string
+      example:
+        id: krr_full
+        title:
+          default: Full tilgang til kontakt- og reservasjonsregisteret
+          lang:
+          - code: en_GB
+            value: Full access to the Contact and Reservation Register
+        description:
+          default: Gir anledning til å lese og endre data i KRR
+          lang:
+          - code: nn_NO
+            value: Gjer høve til å lesa og endra data i KRR
+          - code: en_GB
+            value: Allows you to read and change data in the Contact and Reservation
+              Register
+        delegation_owner_id: "991825827"
+        delegation_source: altinn
+        delegation_source_config:
+        - key: roles
+          value: PRIV
+    Error:
+      title: Root Type for Error
+      description: Generisk modell for å beskrive kjøretidsfeil. Brukes i forbindelse
+        med 4xx og 5xx returer fra API-et.
+      required:
+      - errorDescription
+      - errorCode
+      type: object
+      properties:
+        errorCode:
+          format: int32
+          description: Feilkode. TODO! Kodeliste må beskrives.
+          type: integer
+        errorDescription:
+          description: Beskrivelse av feilen som oppstod.
+          type: string
+      example: |-
+        {
+            "errorCode": 4031,
+            "errorDescription": "Unable to delete the delegation scheme that has active delegations"
+        }
+  securitySchemes:
+    maskinporten:
+      type: oauth2
+      description: Only maskinporten should ever be granted access to this scope
+      flows:
+        clientCredentials:
+          tokenUrl: https://oidc.difi.no/idporten-oidc-provider/token
+          scopes:
+            delegations: Read access to delegations for arbitrary actors and scopes

--- a/pages/eoppslag/assets/delegations_0.2.0_oas.yaml
+++ b/pages/eoppslag/assets/delegations_0.2.0_oas.yaml
@@ -16,7 +16,6 @@ paths:
             En, begge eller ingen av parameterene kan oppgis. 
         get:
             summary: Liste over alle delegeringer som er gjort på et scope
-            operationId: getDelegations
             responses:
                 '200':
                     description: Liste over alle delegeringer som er gjort på dette scopet.
@@ -54,7 +53,6 @@ paths:
         get:
             summary: Lister ut alle delegeringsoppsett
             description: 'Returnerer en liste over alle delegeringsoppsett, valgfritt filtrert på oppgitt owner_id'
-            operationId: getDelegationSchemes
             parameters:
                 -
                     name: owner_id
@@ -74,7 +72,6 @@ paths:
         post:
             summary: Opprett et delegeringsoppsett
             description: Lager et nytt delegeringsoppsett.
-            operationId: createDelegationScheme
             requestBody:
                 description: Delegeringsoppsett som ønskes opprettet.
                 content:
@@ -110,7 +107,6 @@ paths:
         get:
             summary: Hent et delegeringsoppsett
             description: Hent informasjon om et enkelt delegeringsoppsett.
-            operationId: getDelegationScheme
             responses:
                 '200':
                     description: Returnerer et delegeringsoppsett som definert av `DelegationScheme`.
@@ -123,7 +119,6 @@ paths:
         put:
             summary: Oppdaterer et delegeringsoppsett
             description: Oppdaterer et delegeringsoppsett.
-            operationId: updateDelegationScheme
             requestBody:
                 description: Oppdatert delegeringsoppsett
                 content:
@@ -153,7 +148,6 @@ paths:
         delete:
             summary: Slett et delegeringsoppsett
             description: 'Sletter et eksisterende delegeringsoppsett, hvis delegeringsskilden tillater det.'
-            operationId: deleteDelegationScheme
             responses:
                 '204':
                     description: Oppsettet ble slettet.
@@ -169,135 +163,110 @@ paths:
             -
                 name: delegationSchemeId
                 in: path
-                description: ID på delegeringsoppsett
+                description: ID for delegeringsoppsett
                 required: true
                 schema:
                     type: string
-    '/delegationSchemeOwners/{delegationSchemeOwnerId}':
-        summary: Path for å administrere en enkelt eier av delegeringsoppsett
-        description: >-
-            Endepunkt for å hente, oppdatere og slette spesifikke eiere delegeringsoppsett. Avhengig av
-            delegeringskilde og om det foreligger delegeringsoppsettet knyttet til oppgitte oppsettet vil
-            skriveoperasjoner kunne nektes av delegeringskilden. 
+    '/delegationSchemes/{delegationSchemeId}/scopes':
+        summary: Scopes knyttet til et delegeringsoppsett
+        description: Endepunkt for hente og oppdatere listen med scopes knyttet til et delegeringsoppsett
         get:
-            summary: Hent en eier av delegeringsoppsett
-            description: Henter ut detaljer om en enkelt eier av delegeringsoppsett
-            operationId: getDelegationSchemeOwner
+            summary: Hent liste over alle scopes for et delegeringsoppsett
+            parameters:
+                -
+                    name: delegationSchemeId
+                    in: path
+                    description: ID på delegeringsoppsett
+                    required: true
+                    schema:
+                        type: string
             responses:
                 '200':
-                    description: Returnerer en eier av et delegeringsoppsett
+                    description: Liste av scopes
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/DelegationSchemeOwner'
+                                $ref: '#/components/schemas/ScopeList'
                 '404':
-                    description: Oppgitt eier ble ikke funnet
+                    description: Oppgitt delegeringoppsett-ID finnes ikke
         put:
-            summary: Oppdater en eier av delegeringsoppsett
-            description: Oppdaterer en eksisterende eier av delegeringsoppsett
-            operationId: updateDelegationSchemeOwner
+            summary: Erstatt eksisterende liste av scopes med ny liste med scopes
+            parameters:
+                -
+                    name: delegationSchemeId
+                    in: path
+                    description: ID for delegeringsoppsett
+                    required: true
+                    schema:
+                        type: string
             requestBody:
-                description: Oppdatert eier av delegeringsoppsett
+                description: Ny list med scopes
                 content:
                     application/json:
                         schema:
-                            $ref: '#/components/schemas/DelegationSchemeOwner'
+                            $ref: '#/components/schemas/ScopeList'
                 required: true
-            responses:
-                '202':
-                    description: Eier av delegeringsoppsettet ble oppdatert.
-                '400':
-                    description: Ugyldig eier av delegeringsoppsett. Se respons for nærmere forklaring.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                '403':
-                    description: >-
-                        Ikke tilgang til å oppdatere eier av delegeringsoppsettet. Nærmere forklaring ligger i
-                        response body.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                '404':
-                    description: Forespurte eier av delegeringsoppsett ble ikke funnet.
-        delete:
-            summary: Sletter en eier av delegeringsoppsett
-            description: Sletter en eier av et eksisterende delegeringsoppsett.
-            operationId: deleteDelegationSchemeOwner
             responses:
                 '204':
-                    description: Eier av delegeringsoppsettet ble slettet.
-                '403':
-                    description: >-
-                        Kunne ikke slette eier av delegeringsoppsettet. Nærmere forklaring ligger i response
-                        body.
+                    description: Listen med scopes ble oppdatert
+                '400':
+                    description: Ugyldig liste med scopes
                     content:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Error'
-                '404':
-                    description: Forespurte eier delegeringsoppsett ble ikke funnet.
         parameters:
             -
-                name: delegationSchemeOwnerId
+                name: delegationSchemeId
                 in: path
-                description: ID på eier av delegeringsoppsett
+                description: ID for delegeringsoppsett
                 required: true
                 schema:
                     type: string
-    /delegationSchemeOwners:
-        summary: Hente ut liste over registrerte eiere av delegeringsoppsett eller registrere en ny
-        description: 'Endepunkt for å hente ut en liste over eiere av delegeringsoppsett, eller for å poste en ny eier.'
-        get:
-            summary: Liste ut eiere
-            description: Henter ut en liste over alle registrerte eiere
-            operationId: getDelegationSchemeOwners
+    '/delegationSchemes/{delegationSchemeId}/scopes/{scope}':
+        summary: Legg til eller fjern tilknytning til oppgitt scope for oppgitt delegeringsoppsett
+        description: >-
+            Endepunkt for å administrere enkeltscopes for det gitte delegeringsoppsettet. PUT vil knytte et
+            nytt scope til delegeringsoppsettet. Hvis scopet allerede finnes, skjer ingenting. DELETE vil
+            fjerne det oppgitte scopet fra listen av scopes knyttet til det gitte delegeringsoppsettet.
+        put:
+            summary: Knytt oppgitt scope med oppgitt delegeringsoppsett
             responses:
-                '200':
-                    description: Returnerer en liste over alle registrerte eiere av delegeringsoppsett.
-                    content:
-                        application/json:
-                            schema:
-                                type: array
-                                items:
-                                    $ref: '#/components/schemas/DelegationSchemeOwner'
-        post:
-            summary: Opprett en eier av delegeringsoppsett
-            description: Lager en ny eier av delegeringsoppsett
-            operationId: createDelegationSchemeOwner
-            requestBody:
-                description: Eieren som skal opprettes.
-                content:
-                    application/json:
-                        schema:
-                            $ref: '#/components/schemas/DelegationSchemeOwner'
-                required: true
-            responses:
-                '201':
-                    description: Eier opprettet.
+                '204':
+                    description: Scope lagt til delegeringsoppsett
                 '400':
-                    description: Ugyldig oppgitt eier av delegeringsoppsett. Se respons for nærmere forklaring.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                '403':
-                    description: >-
-                        Ingen tilgang til å opprette oppgitt eier av delegeringsoppsett. Se respons for
-                        nærmere forklaring.
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/Error'
-                '409':
-                    description: Eieren av delegeringsoppsett finnes allerede.
+                    description: Ugyldig scope
+                '404':
+                    description: Delegeringsoppsett ikke funnet
+        delete:
+            summary: Slett oppgitt scope fra liste av scopes for oppgitt delegeringsoppsett
+            responses:
+                '204':
+                    description: Scope fjernet fra listen
+                '404':
+                    description: Oppgitt scope ikke funnet i listen av scopes for gitt delegeringsoppsett
+        parameters:
+            -
+                name: delegationSchemeId
+                in: path
+                description: ID for delegeringsoppsett
+                required: true
+                schema:
+                    type: string
+            -
+                name: scope
+                in: path
+                description: >-
+                    Navn på nytt scope som skal knyttes til delegeringsoppsettet, eller eksisterende scope som
+                    skal fjernes fra listen av scopes for delegeringsoppsettet.
+                required: true
+                schema:
+                    type: string
 components:
     schemas:
         Delegation:
             title: Root Type for Delegation
-            description: The root of the Delegation type's schema.
+            description: Aktiv delegering i delegeringskilde
             type: object
             properties:
                 consumer_org:
@@ -307,30 +276,22 @@ components:
                     description: Organisasjonsnummer til aktøren som har fått delegert tilgang
                     type: string
                 delegation_scheme:
-                    description: Navn på delegeringsoppsett som det ble delegert på. Inkluderer scope-prefix.
+                    description: Navn på delegeringsoppsett som det ble delegert på.
                     type: string
-                includes_scopes:
-                    description: >-
-                        Hvilke scopes som er definert under dette delegeringsoppsettet. Inkluderer
-                        scope-prefix.
-                    type: array
-                    items:
-                        type: string
                 created:
                     format: date-time
                     description: UTC-tidspunkt for når delegeringen fant sted
                     type: string
-            example: |-
-                {
-                    "consumer_org": "987654321",
-                    "supplier_org": "976543210",
-                    "delegation_scheme": "difi:krr_read",
-                    "includes_scopes": [
-                        "difi:user/kontaktinfo.read",
-                        "difi:user/varsling.read"
-                    ],
-                    "created": "2018-01-01T12:00:00Z"
-                }
+                scopes:
+                    $ref: '#/components/schemas/ScopeList'
+            example:
+                consumer_org: '987654321'
+                supplier_org: '976543210'
+                delegation_scheme: 'difi:krr_read'
+                scopes:
+                    - 'difi:user/kontaktinfo.read'
+                    - 'difi:user/varsling.read'
+                created: '2018-01-01T12:00:00Z'
         DelegationSourceConfigurationItem:
             title: Root Type for DelegationSourceConfigurationItem
             description: >-
@@ -368,17 +329,17 @@ components:
                     items:
                         $ref: '#/components/schemas/LocalizedStringItem'
             example:
-                value: Departementenes sikkerhets- og serviceorganisasjon
+                value: API for Departementenes sikkerhets- og serviceorganisasjon
                 lang:
                     -
                         code: nb_NO
-                        value: Departementenes sikkerhets- og serviceorganisasjon
+                        value: API for Departementenes sikkerhets- og serviceorganisasjon
                     -
                         code: nn_NO
-                        value: Tryggings- og serviceorganisasjonen til departementa
+                        value: API for Tryggings- og serviceorganisasjonen til departementa
                     -
                         code: en_GB
-                        value: Norwegian Government Security and Service Organisation
+                        value: API for Norwegian Government Security and Service Organisation
                     -
                         code: en_US
                         value: Norwegian Government Security and Service Organization
@@ -396,41 +357,9 @@ components:
                 value:
                     description: Verdi for strengen i oppgitt språk/locale
                     type: string
-            example: '{ "code": "nb_NO", "value": "Departementenes sikkerhets- og serviceorganisasjon" }'
-        DelegationSchemeOwner:
-            title: Root Type for DelegationSchemeOwner
-            description: Beskriver en eier av et delegeringsoppsett
-            required:
-                - id
-                - name
-            type: object
-            properties:
-                id:
-                    description: >-
-                        Unik identifikator for eier av delegeringsoppsett. I Norge er dette
-                        organisasjonsnummer fra enhetsregisteret.
-                    pattern: '^[a-zA-Z0-9_]+$'
-                    type: string
-                name:
-                    $ref: '#/components/schemas/LocalizedString'
-                    description: Navn på eier av delegeringsoppsett
             example:
-                id: '974761424'
-                name:
-                    value: Departementenes sikkerhets- og serviceorganisasjon
-                    lang:
-                        -
-                            code: nb_NO
-                            value: Departementenes sikkerhets- og serviceorganisasjon
-                        -
-                            code: nn_NO
-                            value: Tryggings- og serviceorganisasjonen til departementa
-                        -
-                            code: en_GB
-                            value: Norwegian Government Security and Service Organisation
-                        -
-                            code: en_US
-                            value: Norwegian Government Security and Service Organization
+                code: nb_NO
+                value: API for Departementenes sikkerhets- og serviceorganisasjon
         DelegationScheme:
             title: Root Type for DelegationSchemeDefinition
             description: >-
@@ -438,17 +367,14 @@ components:
                 ressurs i oppgitt delegeringskilde.
             required:
                 - id
-                - delegation_scheme_owner_id
+                - owner_org
                 - scopes
             type: object
             properties:
                 title:
                     $ref: '#/components/schemas/LocalizedString'
-                    description: Menneske-vennlig tittel for delegeringsoppsett
                 description:
                     $ref: '#/components/schemas/LocalizedString'
-                    description: Valgfri beskrivelse av delegeringsoppsett
-                    maxLength: 300
                 delegation_source:
                     description: >-
                         Identifikator for kilden hvor delegeringer på knyttet til dette delegeringsoppsettet
@@ -461,27 +387,20 @@ components:
                     type: array
                     items:
                         $ref: '#/components/schemas/DelegationSourceConfigurationItem'
-                delegation_scheme_owner_id:
-                    description: >-
-                        Eier av delegeringsoppsettet. Må referere en eksisterende `delegationSchemeOwner`
-                        entitet
-                    type: string
                 id:
-                    description: Identifikator for delegeringsoppsett
+                    description: Unik identifikator for delegeringsoppsett
                     pattern: '^[a-zA-Z0-9_]+$'
                     type: string
                 scopes:
-                    description: Scopes som er assosiert med dette delegeringsoppsettet
-                    type: array
-                    items:
-                        type: string
+                    $ref: '#/components/schemas/ScopeList'
+                owner_org:
+                    description: Eier av delegeringsoppsettet. Norsk organisasjonsnummer.
+                    type: string
             example:
                 id: krr_full
                 scopes:
-                    - 'difi:global/varslingsstatus.read'
-                    - 'difi:global/varslingsstatus.write'
-                    - 'difi:global/kontaktinformasjon.read'
-                    - 'difi:global/kontaktinformasjon.write'
+                    - 'difi:user/kontaktinfo.read'
+                    - 'difi:user/varsling.read'
                 title:
                     default: Full tilgang til kontakt- og reservasjonsregisteret
                     lang:
@@ -497,7 +416,7 @@ components:
                         -
                             code: en_GB
                             value: Allows you to read and change data in the Contact and Reservation Register
-                delegation_owner_id: '991825827'
+                owner_org: '991825827'
                 delegation_source: altinn
                 delegation_source_config:
                     -
@@ -525,6 +444,17 @@ components:
                     "errorCode": 4031,
                     "errorDescription": "Unable to delete the delegation scheme that has active delegations"
                 }
+        ScopeList:
+            title: Liste med scopes
+            description: Scopes assosiert med et delegeringsoppsett
+            type: array
+            items:
+                type: string
+            example: |-
+                [
+                    "difi:user/kontaktinfo.read",
+                    "difi:user/varsling.read"
+                ]
     securitySchemes:
         maskinporten:
             type: oauth2

--- a/pages/eoppslag/assets/delegations_0.2.0_oas.yaml
+++ b/pages/eoppslag/assets/delegations_0.2.0_oas.yaml
@@ -1,503 +1,536 @@
----
 openapi: 3.0.2
 info:
-  title: Maskinporten Delegeringskilde API
-  description: API som delegeringskilder må implementere for integrasjon med Maskinportens
-    tilgangskontroll
-  contact:
-    name: Bjørn Dybvik Langfors
-    email: bdl@brreg.no
-  version: 0.2.0
+    title: Maskinporten Delegeringskilde API
+    description: API som delegeringskilder må implementere for integrasjon med Maskinportens tilgangskontroll
+    contact:
+        name: Bjørn Dybvik Langfors
+        email: bdl@brreg.no
+    version: 0.2.0
 paths:
-  /delegations/:
-    summary: Henter ut en liste over alle delegeringer som er gjort på et scope
-    description: 'Scope oppgis som query-parameter for å unngå problemer med "/" i
-      paths. Kan filtreres på `consumer_org`, som returnerer alle delegeringer gitt
-      av oppgitt organisasjonsnummer. Hvis `supplier_org` oppgis, returneres alle
-      delegeringer som oppgitt organisasjonsnummer har mottatt. En, begge eller ingen
-      av parameterene kan oppgis. '
-    get:
-      summary: Liste over alle delegeringer som er gjort på et scope
-      operationId: getDelegations
-      responses:
-        200:
-          description: Liste over alle delegeringer som er gjort på dette scopet.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Delegation'
-    parameters:
-    - name: scope
-      in: query
-      description: Scope som registrert i ID-porten
-      required: true
-      schema:
-        type: string
-    - name: consumer_org
-      in: query
-      description: Viser delegeringer begrenset til de utført av oppgitt organisasjonsnummer
-      schema:
-        type: string
-    - name: supplier_org
-      in: query
-      description: Viser delegeringer begrenset til de gitt til oppgitt organisasjonsnummer
-      schema:
-        type: string
-  /delegationSchemes:
-    summary: Hente ut liste over registrerte delegeringsoppsett eller registrere et
-      nytt
-    description: Endepunkt for å hente ut en liste over delegeringsoppsett (valgfritt
-      filtrert på eier), eller for å poste et nytt oppsett.
-    get:
-      summary: Lister ut alle delegeringsoppsett
-      description: Returnerer en liste over alle delegeringsoppsett, valgfritt filtrert
-        på oppgitt owner_id
-      operationId: getDelegationSchemes
-      parameters:
-      - name: owner_id
-        in: query
-        description: Begrens liste til delegeringsoppsett eid av oppgitt owner_id
-        schema:
-          type: string
-      responses:
-        200:
-          description: Returnerer en liste av delegeringsoppsett
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DelegationScheme'
-    post:
-      summary: Opprett et delegeringsoppsett
-      description: Lager et nytt delegeringsoppsett.
-      operationId: createDelegationScheme
-      requestBody:
-        description: Delegeringsoppsett som ønskes opprettet.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DelegationScheme'
-        required: true
-      responses:
-        201:
-          description: Delegeringsoppsettet er opprettet.
-        400:
-          description: Ugyldig delegeringsoppsett. Se respons for nærmere forklaring.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        403:
-          description: Ingen tilgang til å opprette oppgitt delegeringsoppsett. Se
-            respons for nærmere forklaring.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        409:
-          description: Et delegeringsskjema med samme id finnes allerede.
-  /delegationSchemes/{delegationSchemeId}:
-    summary: Path for å administrere et enkelt delegeringsoppsett
-    description: 'Endepunkt for å hente, oppdatere og slette spesifikke delegeringsoppsett.
-      Avhengig av delegeringskilde og om det foreligger delegeringer knyttet til oppgitte
-      oppsettet vil skriveoperasjoner kunne nektes av delegeringskilden. '
-    get:
-      summary: Hent et delegeringsoppsett
-      description: Hent informasjon om et enkelt delegeringsoppsett.
-      operationId: getDelegationScheme
-      responses:
-        200:
-          description: Returnerer et delegeringsoppsett som definert av `DelegationScheme`.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DelegationScheme'
-        404:
-          description: Forespurte delegeringsoppsett ble ikke funnet.
-    put:
-      summary: Oppdaterer et delegeringsoppsett
-      description: Oppdaterer et delegeringsoppsett.
-      operationId: updateDelegationScheme
-      requestBody:
-        description: Oppdatert delegeringsoppsett
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DelegationScheme'
-        required: true
-      responses:
-        202:
-          description: Delegeringsoppsettet ble oppdatert.
-        400:
-          description: Ugyldig delegeringsoppsett. Se respons for nærmere forklaring.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        403:
-          description: Ikke tilgang til å oppdatere delegeringsoppsettet. Nærmere
-            forklaring ligger i response body.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Forespurte delegeringsoppsett ble ikke funnet.
-    delete:
-      summary: Slett et delegeringsoppsett
-      description: Sletter et eksisterende delegeringsoppsett, hvis delegeringsskilden
-        tillater det.
-      operationId: deleteDelegationScheme
-      responses:
-        204:
-          description: Oppsettet ble slettet.
-        403:
-          description: Kunne ikke slette delegeringsoppsettet. Nærmere forklaring
-            ligger i response body.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Forespurte delegeringsoppsett ble ikke funnet.
-    parameters:
-    - name: delegationSchemeId
-      in: path
-      description: ID på delegeringsoppsett
-      required: true
-      schema:
-        type: string
-  /delegationSchemeOwners/{delegationSchemeOwnerId}:
-    summary: Path for å administrere en enkelt eier av delegeringsoppsett
-    description: 'Endepunkt for å hente, oppdatere og slette spesifikke eiere delegeringsoppsett.
-      Avhengig av delegeringskilde og om det foreligger delegeringsoppsettet knyttet
-      til oppgitte oppsettet vil skriveoperasjoner kunne nektes av delegeringskilden. '
-    get:
-      summary: Hent en eier av delegeringsoppsett
-      description: Henter ut detaljer om en enkelt eier av delegeringsoppsett
-      operationId: getDelegationSchemeOwner
-      responses:
-        200:
-          description: Returnerer en eier av et delegeringsoppsett
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DelegationSchemeOwner'
-        404:
-          description: Oppgitt eier ble ikke funnet
-    put:
-      summary: Oppdater en eier av delegeringsoppsett
-      description: Oppdaterer en eksisterende eier av delegeringsoppsett
-      operationId: updateDelegationSchemeOwner
-      requestBody:
-        description: Oppdatert eier av delegeringsoppsett
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DelegationSchemeOwner'
-        required: true
-      responses:
-        202:
-          description: Eier av delegeringsoppsettet ble oppdatert.
-        400:
-          description: Ugyldig eier av delegeringsoppsett. Se respons for nærmere
-            forklaring.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        403:
-          description: Ikke tilgang til å oppdatere eier av delegeringsoppsettet.
-            Nærmere forklaring ligger i response body.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Forespurte eier av delegeringsoppsett ble ikke funnet.
-    delete:
-      summary: Sletter en eier av delegeringsoppsett
-      description: Sletter en eier av et eksisterende delegeringsoppsett.
-      operationId: deleteDelegationSchemeOwner
-      responses:
-        204:
-          description: Eier av delegeringsoppsettet ble slettet.
-        403:
-          description: Kunne ikke slette eier av delegeringsoppsettet. Nærmere forklaring
-            ligger i response body.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        404:
-          description: Forespurte eier delegeringsoppsett ble ikke funnet.
-    parameters:
-    - name: delegationSchemeOwnerId
-      in: path
-      description: ID på eier av delegeringsoppsett
-      required: true
-      schema:
-        type: string
-  /delegationSchemeOwners:
-    summary: Hente ut liste over registrerte eiere av delegeringsoppsett eller registrere
-      en ny
-    description: Endepunkt for å hente ut en liste over eiere av delegeringsoppsett,
-      eller for å poste en ny eier.
-    get:
-      summary: Liste ut eiere
-      description: Henter ut en liste over alle registrerte eiere
-      operationId: getDelegationSchemeOwners
-      responses:
-        200:
-          description: Returnerer en liste over alle registrerte eiere av delegeringsoppsett.
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/DelegationSchemeOwner'
-    post:
-      summary: Opprett en eier av delegeringsoppsett
-      description: Lager en ny eier av delegeringsoppsett
-      operationId: createDelegationSchemeOwner
-      requestBody:
-        description: Eieren som skal opprettes.
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DelegationSchemeOwner'
-        required: true
-      responses:
-        201:
-          description: Eier opprettet.
-        400:
-          description: Ugyldig oppgitt eier av delegeringsoppsett. Se respons for
-            nærmere forklaring.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        403:
-          description: Ingen tilgang til å opprette oppgitt eier av delegeringsoppsett.
-            Se respons for nærmere forklaring.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-        409:
-          description: Eieren av delegeringsoppsett finnes allerede.
+    /delegations/:
+        summary: Henter ut en liste over alle delegeringer som er gjort på et scope
+        description: >-
+            Scope oppgis som query-parameter for å unngå problemer med "/" i paths. Kan filtreres på
+            `consumer_org`, som returnerer alle delegeringer gitt av oppgitt organisasjonsnummer. Hvis
+            `supplier_org` oppgis, returneres alle delegeringer som oppgitt organisasjonsnummer har mottatt.
+            En, begge eller ingen av parameterene kan oppgis. 
+        get:
+            summary: Liste over alle delegeringer som er gjort på et scope
+            operationId: getDelegations
+            responses:
+                '200':
+                    description: Liste over alle delegeringer som er gjort på dette scopet.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/Delegation'
+        parameters:
+            -
+                name: scope
+                in: query
+                description: Scope som registrert i ID-porten
+                required: true
+                schema:
+                    type: string
+            -
+                name: consumer_org
+                in: query
+                description: Viser delegeringer begrenset til de utført av oppgitt organisasjonsnummer
+                schema:
+                    type: string
+            -
+                name: supplier_org
+                in: query
+                description: Viser delegeringer begrenset til de gitt til oppgitt organisasjonsnummer
+                schema:
+                    type: string
+    /delegationSchemes:
+        summary: Hente ut liste over registrerte delegeringsoppsett eller registrere et nytt
+        description: >-
+            Endepunkt for å hente ut en liste over delegeringsoppsett (valgfritt filtrert på eier), eller for
+            å poste et nytt oppsett.
+        get:
+            summary: Lister ut alle delegeringsoppsett
+            description: 'Returnerer en liste over alle delegeringsoppsett, valgfritt filtrert på oppgitt owner_id'
+            operationId: getDelegationSchemes
+            parameters:
+                -
+                    name: owner_id
+                    in: query
+                    description: Begrens liste til delegeringsoppsett eid av oppgitt owner_id
+                    schema:
+                        type: string
+            responses:
+                '200':
+                    description: Returnerer en liste av delegeringsoppsett
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/DelegationScheme'
+        post:
+            summary: Opprett et delegeringsoppsett
+            description: Lager et nytt delegeringsoppsett.
+            operationId: createDelegationScheme
+            requestBody:
+                description: Delegeringsoppsett som ønskes opprettet.
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DelegationScheme'
+                required: true
+            responses:
+                '201':
+                    description: Delegeringsoppsettet er opprettet.
+                '400':
+                    description: Ugyldig delegeringsoppsett. Se respons for nærmere forklaring.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '403':
+                    description: >-
+                        Ingen tilgang til å opprette oppgitt delegeringsoppsett. Se respons for nærmere
+                        forklaring.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '409':
+                    description: Et delegeringsskjema med samme id finnes allerede.
+    '/delegationSchemes/{delegationSchemeId}':
+        summary: Path for å administrere et enkelt delegeringsoppsett
+        description: >-
+            Endepunkt for å hente, oppdatere og slette spesifikke delegeringsoppsett. Avhengig av
+            delegeringskilde og om det foreligger delegeringer knyttet til oppgitte oppsettet vil
+            skriveoperasjoner kunne nektes av delegeringskilden. 
+        get:
+            summary: Hent et delegeringsoppsett
+            description: Hent informasjon om et enkelt delegeringsoppsett.
+            operationId: getDelegationScheme
+            responses:
+                '200':
+                    description: Returnerer et delegeringsoppsett som definert av `DelegationScheme`.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DelegationScheme'
+                '404':
+                    description: Forespurte delegeringsoppsett ble ikke funnet.
+        put:
+            summary: Oppdaterer et delegeringsoppsett
+            description: Oppdaterer et delegeringsoppsett.
+            operationId: updateDelegationScheme
+            requestBody:
+                description: Oppdatert delegeringsoppsett
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DelegationScheme'
+                required: true
+            responses:
+                '202':
+                    description: Delegeringsoppsettet ble oppdatert.
+                '400':
+                    description: Ugyldig delegeringsoppsett. Se respons for nærmere forklaring.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '403':
+                    description: >-
+                        Ikke tilgang til å oppdatere delegeringsoppsettet. Nærmere forklaring ligger i
+                        response body.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '404':
+                    description: Forespurte delegeringsoppsett ble ikke funnet.
+        delete:
+            summary: Slett et delegeringsoppsett
+            description: 'Sletter et eksisterende delegeringsoppsett, hvis delegeringsskilden tillater det.'
+            operationId: deleteDelegationScheme
+            responses:
+                '204':
+                    description: Oppsettet ble slettet.
+                '403':
+                    description: Kunne ikke slette delegeringsoppsettet. Nærmere forklaring ligger i response body.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '404':
+                    description: Forespurte delegeringsoppsett ble ikke funnet.
+        parameters:
+            -
+                name: delegationSchemeId
+                in: path
+                description: ID på delegeringsoppsett
+                required: true
+                schema:
+                    type: string
+    '/delegationSchemeOwners/{delegationSchemeOwnerId}':
+        summary: Path for å administrere en enkelt eier av delegeringsoppsett
+        description: >-
+            Endepunkt for å hente, oppdatere og slette spesifikke eiere delegeringsoppsett. Avhengig av
+            delegeringskilde og om det foreligger delegeringsoppsettet knyttet til oppgitte oppsettet vil
+            skriveoperasjoner kunne nektes av delegeringskilden. 
+        get:
+            summary: Hent en eier av delegeringsoppsett
+            description: Henter ut detaljer om en enkelt eier av delegeringsoppsett
+            operationId: getDelegationSchemeOwner
+            responses:
+                '200':
+                    description: Returnerer en eier av et delegeringsoppsett
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/DelegationSchemeOwner'
+                '404':
+                    description: Oppgitt eier ble ikke funnet
+        put:
+            summary: Oppdater en eier av delegeringsoppsett
+            description: Oppdaterer en eksisterende eier av delegeringsoppsett
+            operationId: updateDelegationSchemeOwner
+            requestBody:
+                description: Oppdatert eier av delegeringsoppsett
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DelegationSchemeOwner'
+                required: true
+            responses:
+                '202':
+                    description: Eier av delegeringsoppsettet ble oppdatert.
+                '400':
+                    description: Ugyldig eier av delegeringsoppsett. Se respons for nærmere forklaring.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '403':
+                    description: >-
+                        Ikke tilgang til å oppdatere eier av delegeringsoppsettet. Nærmere forklaring ligger i
+                        response body.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '404':
+                    description: Forespurte eier av delegeringsoppsett ble ikke funnet.
+        delete:
+            summary: Sletter en eier av delegeringsoppsett
+            description: Sletter en eier av et eksisterende delegeringsoppsett.
+            operationId: deleteDelegationSchemeOwner
+            responses:
+                '204':
+                    description: Eier av delegeringsoppsettet ble slettet.
+                '403':
+                    description: >-
+                        Kunne ikke slette eier av delegeringsoppsettet. Nærmere forklaring ligger i response
+                        body.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '404':
+                    description: Forespurte eier delegeringsoppsett ble ikke funnet.
+        parameters:
+            -
+                name: delegationSchemeOwnerId
+                in: path
+                description: ID på eier av delegeringsoppsett
+                required: true
+                schema:
+                    type: string
+    /delegationSchemeOwners:
+        summary: Hente ut liste over registrerte eiere av delegeringsoppsett eller registrere en ny
+        description: 'Endepunkt for å hente ut en liste over eiere av delegeringsoppsett, eller for å poste en ny eier.'
+        get:
+            summary: Liste ut eiere
+            description: Henter ut en liste over alle registrerte eiere
+            operationId: getDelegationSchemeOwners
+            responses:
+                '200':
+                    description: Returnerer en liste over alle registrerte eiere av delegeringsoppsett.
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/DelegationSchemeOwner'
+        post:
+            summary: Opprett en eier av delegeringsoppsett
+            description: Lager en ny eier av delegeringsoppsett
+            operationId: createDelegationSchemeOwner
+            requestBody:
+                description: Eieren som skal opprettes.
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/DelegationSchemeOwner'
+                required: true
+            responses:
+                '201':
+                    description: Eier opprettet.
+                '400':
+                    description: Ugyldig oppgitt eier av delegeringsoppsett. Se respons for nærmere forklaring.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '403':
+                    description: >-
+                        Ingen tilgang til å opprette oppgitt eier av delegeringsoppsett. Se respons for
+                        nærmere forklaring.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/Error'
+                '409':
+                    description: Eieren av delegeringsoppsett finnes allerede.
 components:
-  schemas:
-    Delegation:
-      title: Root Type for Delegation
-      description: The root of the Delegation type's schema.
-      type: object
-      properties:
-        consumer_org:
-          description: Organisasjonsnummer til aktøren som gir delegeringen
-          type: string
-        supplier_org:
-          description: Organisasjonsnummer til aktøren som har fått delegert tilgang
-          type: string
-        delegation_scheme:
-          description: Navn på delegeringsoppsett som det ble delegert på. Inkluderer
-            scope-prefix.
-          type: string
-        includes_scopes:
-          description: Hvilke scopes som er definert under dette delegeringsoppsettet.
-            Inkluderer scope-prefix.
-          type: array
-          items:
-            type: string
-        created:
-          format: date-time
-          description: UTC-tidspunkt for når delegeringen fant sted
-          type: string
-      example: |-
-        {
-            "consumer_org": "987654321",
-            "supplier_org": "976543210",
-            "delegation_scheme": "difi:krr_read",
-            "includes_scopes": [
-                "difi:user/kontaktinfo.read",
-                "difi:user/varsling.read"
-            ],
-            "created": "2018-01-01T12:00:00Z"
-        }
-    DelegationSourceConfigurationItem:
-      title: Root Type for DelegationSourceConfigurationItem
-      description: Generisk nøkkel/verdi-par for å kunne oppgi vilkårlige attributter
-        for en delegationScheme spesifikke for valgt delegationSource
-      required:
-      - key
-      - value
-      type: object
-      properties:
-        key:
-          description: Nøkkelnavn for konfigurasjonsfelt
-          pattern: ^[a-zA-Z0-9_]+$
-          type: string
-        value:
-          description: Nøkkelverdi for konfigurasjonsfelt
-          type: string
-      example: "{ \n    \"key\": \"roles\",\n    \"value\": \"PRIV,UTINN\"\n}"
-    LocalizedString:
-      description: Modell for å utrykke en streng i flere språk / locales.
-      required:
-      - default
-      type: object
-      properties:
-        default:
-          description: Representasjon som skal brukes når ingen andre språk er oppgitt
-            eller er aktuelle
-          type: string
-        lang:
-          description: Liste med oversettelser av strengen i ulike språk/locales
-          type: array
-          items:
-            $ref: '#/components/schemas/LocalizedStringItem'
-      example:
-        value: Departementenes sikkerhets- og serviceorganisasjon
-        lang:
-        - code: nb_NO
-          value: Departementenes sikkerhets- og serviceorganisasjon
-        - code: nn_NO
-          value: Tryggings- og serviceorganisasjonen til departementa
-        - code: en_GB
-          value: Norwegian Government Security and Service Organisation
-        - code: en_US
-          value: Norwegian Government Security and Service Organization
-    LocalizedStringItem:
-      title: Root Type for LocalizedStringItem
-      description: En streng oppgitt i henhold til et språk/locale som definert i
-        IETF BCP 47
-      required:
-      - code
-      - value
-      type: object
-      properties:
-        code:
-          description: IETF BCP 47 language tag
-          type: string
-        value:
-          description: Verdi for strengen i oppgitt språk/locale
-          type: string
-      example: '{ "code": "nb_NO", "value": "Departementenes sikkerhets- og serviceorganisasjon"
-        }'
-    DelegationSchemeOwner:
-      title: Root Type for DelegationSchemeOwner
-      description: Beskriver en eier av et delegeringsoppsett
-      required:
-      - id
-      - name
-      type: object
-      properties:
-        id:
-          description: Unik identifikator for eier av delegeringsoppsett. I Norge
-            er dette organisasjonsnummer fra enhetsregisteret.
-          pattern: ^[a-zA-Z0-9_]+$
-          type: string
-        name:
-          $ref: '#/components/schemas/LocalizedString'
-          description: Navn på eier av delegeringsoppsett
-      example:
-        id: "974761424"
-        name:
-          value: Departementenes sikkerhets- og serviceorganisasjon
-          lang:
-          - code: nb_NO
-            value: Departementenes sikkerhets- og serviceorganisasjon
-          - code: nn_NO
-            value: Tryggings- og serviceorganisasjonen til departementa
-          - code: en_GB
-            value: Norwegian Government Security and Service Organisation
-          - code: en_US
-            value: Norwegian Government Security and Service Organization
-    DelegationScheme:
-      title: Root Type for DelegationSchemeDefinition
-      description: Modell som beskriver et delegeringsoppsett. Dette vil tilgjengeliggjøres
-        som en delegerbar ressurs i oppgitt delegeringskilde.
-      required:
-      - id
-      - delegation_scheme_owner_id
-      type: object
-      properties:
-        title:
-          $ref: '#/components/schemas/LocalizedString'
-          description: Menneske-vennlig tittel for delegeringsoppsett
-        description:
-          $ref: '#/components/schemas/LocalizedString'
-          description: Valgfri beskrivelse av delegeringsoppsett
-          maxLength: 300
-        delegation_source:
-          description: Identifikator for kilden hvor delegeringer på knyttet til dette
-            delegeringsoppsettet utføres.
-          pattern: ^[a-zA-Z0-9_]+$
-          type: string
-          example: altinn
-        delegation_source_config:
-          description: Valgfri liste med nøkkel-verdi-par som benyttes mot delegeringskilden.
-          type: array
-          items:
-            $ref: '#/components/schemas/DelegationSourceConfigurationItem'
-        delegation_scheme_owner_id:
-          description: Eier av delegeringsoppsettet. Må referere en eksisterende `delegationSchemeOwner`
-            entitet
-          type: string
-        id:
-          description: Identifikator for delegeringsoppsett
-          pattern: ^[a-zA-Z0-9_]+$
-          type: string
-      example:
-        id: krr_full
-        title:
-          default: Full tilgang til kontakt- og reservasjonsregisteret
-          lang:
-          - code: en_GB
-            value: Full access to the Contact and Reservation Register
-        description:
-          default: Gir anledning til å lese og endre data i KRR
-          lang:
-          - code: nn_NO
-            value: Gjer høve til å lesa og endra data i KRR
-          - code: en_GB
-            value: Allows you to read and change data in the Contact and Reservation
-              Register
-        delegation_owner_id: "991825827"
-        delegation_source: altinn
-        delegation_source_config:
-        - key: roles
-          value: PRIV
-    Error:
-      title: Root Type for Error
-      description: Generisk modell for å beskrive kjøretidsfeil. Brukes i forbindelse
-        med 4xx og 5xx returer fra API-et.
-      required:
-      - errorDescription
-      - errorCode
-      type: object
-      properties:
-        errorCode:
-          format: int32
-          description: Feilkode. TODO! Kodeliste må beskrives.
-          type: integer
-        errorDescription:
-          description: Beskrivelse av feilen som oppstod.
-          type: string
-      example: |-
-        {
-            "errorCode": 4031,
-            "errorDescription": "Unable to delete the delegation scheme that has active delegations"
-        }
-  securitySchemes:
-    maskinporten:
-      type: oauth2
-      description: Only maskinporten should ever be granted access to this scope
-      flows:
-        clientCredentials:
-          tokenUrl: https://oidc.difi.no/idporten-oidc-provider/token
-          scopes:
-            delegations: Read access to delegations for arbitrary actors and scopes
+    schemas:
+        Delegation:
+            title: Root Type for Delegation
+            description: The root of the Delegation type's schema.
+            type: object
+            properties:
+                consumer_org:
+                    description: Organisasjonsnummer til aktøren som gir delegeringen
+                    type: string
+                supplier_org:
+                    description: Organisasjonsnummer til aktøren som har fått delegert tilgang
+                    type: string
+                delegation_scheme:
+                    description: Navn på delegeringsoppsett som det ble delegert på. Inkluderer scope-prefix.
+                    type: string
+                includes_scopes:
+                    description: >-
+                        Hvilke scopes som er definert under dette delegeringsoppsettet. Inkluderer
+                        scope-prefix.
+                    type: array
+                    items:
+                        type: string
+                created:
+                    format: date-time
+                    description: UTC-tidspunkt for når delegeringen fant sted
+                    type: string
+            example: |-
+                {
+                    "consumer_org": "987654321",
+                    "supplier_org": "976543210",
+                    "delegation_scheme": "difi:krr_read",
+                    "includes_scopes": [
+                        "difi:user/kontaktinfo.read",
+                        "difi:user/varsling.read"
+                    ],
+                    "created": "2018-01-01T12:00:00Z"
+                }
+        DelegationSourceConfigurationItem:
+            title: Root Type for DelegationSourceConfigurationItem
+            description: >-
+                Generisk nøkkel/verdi-par for å kunne oppgi vilkårlige attributter for en delegationScheme
+                spesifikke for valgt delegationSource
+            required:
+                - key
+                - value
+            type: object
+            properties:
+                key:
+                    description: Nøkkelnavn for konfigurasjonsfelt
+                    pattern: '^[a-zA-Z0-9_]+$'
+                    type: string
+                value:
+                    description: Nøkkelverdi for konfigurasjonsfelt
+                    type: string
+            example: |-
+                { 
+                    "key": "roles",
+                    "value": "PRIV,UTINN"
+                }
+        LocalizedString:
+            description: Modell for å utrykke en streng i flere språk / locales.
+            required:
+                - default
+            type: object
+            properties:
+                default:
+                    description: Representasjon som skal brukes når ingen andre språk er oppgitt eller er aktuelle
+                    type: string
+                lang:
+                    description: Liste med oversettelser av strengen i ulike språk/locales
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/LocalizedStringItem'
+            example:
+                value: Departementenes sikkerhets- og serviceorganisasjon
+                lang:
+                    -
+                        code: nb_NO
+                        value: Departementenes sikkerhets- og serviceorganisasjon
+                    -
+                        code: nn_NO
+                        value: Tryggings- og serviceorganisasjonen til departementa
+                    -
+                        code: en_GB
+                        value: Norwegian Government Security and Service Organisation
+                    -
+                        code: en_US
+                        value: Norwegian Government Security and Service Organization
+        LocalizedStringItem:
+            title: Root Type for LocalizedStringItem
+            description: En streng oppgitt i henhold til et språk/locale som definert i IETF BCP 47
+            required:
+                - code
+                - value
+            type: object
+            properties:
+                code:
+                    description: IETF BCP 47 language tag
+                    type: string
+                value:
+                    description: Verdi for strengen i oppgitt språk/locale
+                    type: string
+            example: '{ "code": "nb_NO", "value": "Departementenes sikkerhets- og serviceorganisasjon" }'
+        DelegationSchemeOwner:
+            title: Root Type for DelegationSchemeOwner
+            description: Beskriver en eier av et delegeringsoppsett
+            required:
+                - id
+                - name
+            type: object
+            properties:
+                id:
+                    description: >-
+                        Unik identifikator for eier av delegeringsoppsett. I Norge er dette
+                        organisasjonsnummer fra enhetsregisteret.
+                    pattern: '^[a-zA-Z0-9_]+$'
+                    type: string
+                name:
+                    $ref: '#/components/schemas/LocalizedString'
+                    description: Navn på eier av delegeringsoppsett
+            example:
+                id: '974761424'
+                name:
+                    value: Departementenes sikkerhets- og serviceorganisasjon
+                    lang:
+                        -
+                            code: nb_NO
+                            value: Departementenes sikkerhets- og serviceorganisasjon
+                        -
+                            code: nn_NO
+                            value: Tryggings- og serviceorganisasjonen til departementa
+                        -
+                            code: en_GB
+                            value: Norwegian Government Security and Service Organisation
+                        -
+                            code: en_US
+                            value: Norwegian Government Security and Service Organization
+        DelegationScheme:
+            title: Root Type for DelegationSchemeDefinition
+            description: >-
+                Modell som beskriver et delegeringsoppsett. Dette vil tilgjengeliggjøres som en delegerbar
+                ressurs i oppgitt delegeringskilde.
+            required:
+                - id
+                - delegation_scheme_owner_id
+                - scopes
+            type: object
+            properties:
+                title:
+                    $ref: '#/components/schemas/LocalizedString'
+                    description: Menneske-vennlig tittel for delegeringsoppsett
+                description:
+                    $ref: '#/components/schemas/LocalizedString'
+                    description: Valgfri beskrivelse av delegeringsoppsett
+                    maxLength: 300
+                delegation_source:
+                    description: >-
+                        Identifikator for kilden hvor delegeringer på knyttet til dette delegeringsoppsettet
+                        utføres.
+                    pattern: '^[a-zA-Z0-9_]+$'
+                    type: string
+                    example: altinn
+                delegation_source_config:
+                    description: Valgfri liste med nøkkel-verdi-par som benyttes mot delegeringskilden.
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/DelegationSourceConfigurationItem'
+                delegation_scheme_owner_id:
+                    description: >-
+                        Eier av delegeringsoppsettet. Må referere en eksisterende `delegationSchemeOwner`
+                        entitet
+                    type: string
+                id:
+                    description: Identifikator for delegeringsoppsett
+                    pattern: '^[a-zA-Z0-9_]+$'
+                    type: string
+                scopes:
+                    description: Scopes som er assosiert med dette delegeringsoppsettet
+                    type: array
+                    items:
+                        type: string
+            example:
+                id: krr_full
+                scopes:
+                    - 'difi:global/varslingsstatus.read'
+                    - 'difi:global/varslingsstatus.write'
+                    - 'difi:global/kontaktinformasjon.read'
+                    - 'difi:global/kontaktinformasjon.write'
+                title:
+                    default: Full tilgang til kontakt- og reservasjonsregisteret
+                    lang:
+                        -
+                            code: en_GB
+                            value: Full access to the Contact and Reservation Register
+                description:
+                    default: Gir anledning til å lese og endre data i KRR
+                    lang:
+                        -
+                            code: nn_NO
+                            value: Gjer høve til å lesa og endra data i KRR
+                        -
+                            code: en_GB
+                            value: Allows you to read and change data in the Contact and Reservation Register
+                delegation_owner_id: '991825827'
+                delegation_source: altinn
+                delegation_source_config:
+                    -
+                        key: roles
+                        value: PRIV
+        Error:
+            title: Root Type for Error
+            description: >-
+                Generisk modell for å beskrive kjøretidsfeil. Brukes i forbindelse med 4xx og 5xx returer fra
+                API-et.
+            required:
+                - errorDescription
+                - errorCode
+            type: object
+            properties:
+                errorCode:
+                    format: int32
+                    description: Feilkode. TODO! Kodeliste må beskrives.
+                    type: integer
+                errorDescription:
+                    description: Beskrivelse av feilen som oppstod.
+                    type: string
+            example: |-
+                {
+                    "errorCode": 4031,
+                    "errorDescription": "Unable to delete the delegation scheme that has active delegations"
+                }
+    securitySchemes:
+        maskinporten:
+            type: oauth2
+            description: Only maskinporten should ever be granted access to this scope
+            flows:
+                clientCredentials:
+                    tokenUrl: 'https://oidc.difi.no/idporten-oidc-provider/token'
+                    scopes:
+                        delegations: Read access to delegations for arbitrary actors and scopes

--- a/pages/eoppslag/eoppslag_sbb_oauth2_grensesnitt.md
+++ b/pages/eoppslag/eoppslag_sbb_oauth2_grensesnitt.md
@@ -24,8 +24,8 @@ Utledning av grensesnittsdefinisjonen kan leses [her](/eoppslag_sbb_oauth2_admin
 
 Dette APIet blir kun brukt av Token-tjenesten for å registrere delegerbare ressurser og validere gjeldende delegeringsforhold.
 
-> Forslag til design er dokumentert i OAS3 her: [versjon 0.1.0](
-https://github.com/joergenb/oauth2-veileder/blob/gh-pages/pages/eoppslag/assets/delegations_0.1.0_oas.yaml)
+> Forslag til design er dokumentert i OAS3 her: [versjon 0.2.0](
+https://github.com/joergenb/oauth2-veileder/blob/gh-pages/pages/eoppslag/assets/delegations_0.2.0_oas.yaml)
 
 ### 3. Grensesnitt mellom API-katalog og token-tjenestens
 


### PR DESCRIPTION
Her er utkast til API for registrering av delegerbare ressurser og oppslag på delegeringer knyttet til disse. 

Highlights:

- Path for CRUD og utlisting av delegationScheme (på norsk kalt "delegeringsoppsett" i mangel av et bedre ord). Utlisting kan filtreres på eier.
- CRUD og utlisting av eiere av delegeringsoppsett.
- Generisk modell for l10n av strenger (som skal brukes i UI)

Har valgt å ha eiere som en egen ressurs, og la delegationSchemes referere disse. Dette åpner for å enklere kunne gruppere schemes etter eiere i portaler/UI. 

Relasjonen mellom oppsett og eier kunne muligens vært håndtert mer elegant med å støtte OData (f.eks. registrere eier/oppsett i ett kall, bruke $expand i lese-operasjoner etc), men dette drar inn en del strengt tatt unødvendig kompleksitet. 

Modellene fra MP-APIet er delvis gjenbrukt, med et par endringer (primært ift språkstøtte). Inkluderer ikke RAML i denne PR-en, i tilfelle vi ønsker å gjøre justeringer på modellene først. Men tenker at det er en fordel at vi i så stor grad som mulig bør benytte samme modellene i begge API-ene.

Ser frem til dine innspill og kommentarer!

God påske :)
